### PR TITLE
Copy latest esphome configs for zeroconf from tube_gateways by tube0013

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ Experimental! ESPHome component with tcp-to-serial and zeroconf feature for auto
 
 Advertises in this format:
 ```
-zha_ezsp_zeroconf  _ezsp._tcp  local
-   hostname = [zha_ezsp_zeroconf.local]
+_esphome_zb_gw_efr32._tcp      local
+   hostname = [esphome_zb_gw_efr32.local]
    address = [172.16.0.174]
    port = [8080]
-   txt = ["baud_rate=115200"]
+   txt = ["version=1.0" "location=basement" "radio_type=ezsp" "baud_rate=115200" "data_flow_control=software"]
 ```
 (use e.g. avahi-browse -r -a to see this)

--- a/custom_components/zeroconf/README.md
+++ b/custom_components/zeroconf/README.md
@@ -32,7 +32,7 @@ zeroconf:
     txt:
       version: 1.0
       location: basement
-      radio_type: znp
+      radio_type: ezsp
       baud_rate: 115200
       data_flow_control: software
  ```
@@ -45,7 +45,7 @@ zeroconf:
    hostname = [esphome_zb_gw_efr32.local]
    address = [172.16.0.174]
    port = [6638]
-   txt = ["version=1.0" "location=basement" "radio_type=znp" "baud_rate=115200" "data_flow_control=software"]
+   txt = ["version=1.0" "location=basement" "radio_type=ezsp" "baud_rate=115200" "data_flow_control=software"]
 ```
 
 (Test results obtained with `avahi-browse -a -r`)

--- a/custom_components/zeroconf/README.md
+++ b/custom_components/zeroconf/README.md
@@ -1,48 +1,51 @@
 # Zeroconf custom component for ESPHome
 
 
-Example configuration:
+Example configuration without DNS TXT records:
 
 ```yaml
 zeroconf:
-  - service: myservice
+  - service: esphome_zb_gw_efr32
     protocol: tcp
-    port: 8080
+    port: 6638
  ```
  
  
  Result:
  
  ```
- _myservice._tcp      local
-   hostname = [my_esphome_node.local]
+ _esphome_zb_gw_efr32._tcp      local
+   hostname = [esphome_zb_gw_efr32.local]
    address = [172.16.0.174]
-   port = [8080]
+   port = [6638]
    txt = []
 ```
 
 
-Adding some txt records:
+Now an example with also adding some DNS TXT records as parameters for esphome-zbbridge gateway application version, location, and Zigbee radio configuration to be based along to ZHA integration:
 
 ```yaml
 zeroconf:
-  - service: myservice
+  - service: esphome_zb_gw_efr32
     protocol: tcp
-    port: 8080
+    port: 6638
     txt:
       version: 1.0
       location: basement
+      radio_type: znp
+      baud_rate: 115200
+      data_flow_control: software
  ```
  
  
  Result:
  
  ```
- _myservice._tcp      local
-   hostname = [my_esphome_node.local]
+ _esphome_zb_gw_efr32._tcp      local
+   hostname = [esphome_zb_gw_efr32.local]
    address = [172.16.0.174]
-   port = [8080]
-   txt = ["version=1.0" "location=basement"]
+   port = [6638]
+   txt = ["version=1.0" "location=basement" "radio_type=znp" "baud_rate=115200" "data_flow_control=software"]
 ```
 
 (Test results obtained with `avahi-browse -a -r`)

--- a/zha-ezsp-zeroconf.yaml
+++ b/zha-ezsp-zeroconf.yaml
@@ -32,11 +32,15 @@ serial_server:
   multi_client: false # optional, default is false. Set to true to allow multiple simultaneous connections
 
 zeroconf:
-  - service: ezsp
+  - service: esphome_zb_gw_efr32
     protocol: tcp
     port: 8080
     txt:
+      version: 1.0
+      location: basement
+      radio_type: ezsp
       baud_rate: 115200
+      data_flow_control: software
 
 # optional binary sensor to monitor serial connection:
 binary_sensor:


### PR DESCRIPTION
With the exception of hostname and service name copy latest esphome configs for zeroconf from tube_gateways by tube0013 as it is so far only whitelisted Zigbee gateways in the ZHA integration component inside Home Assistant core repository:

https://www.home-assistant.io/integrations/zha#discovery-via-usb-or-zeroconf

https://github.com/tube0013/tube_gateways/tree/main/esphome

https://github.com/tube0013/tube_gateways/blob/ed3d541a29890699a6e8e9550af44c537712751d/V2_tube_zb_gw_cc2752p2/ESPHome/tube_zb_gw_cc2652p2v2.yml

https://github.com/tube0013/tube_gateways/blob/7bde5f09852b95fd98d146f659464678bd6ce2f9/tube_zb_gw_efr32/Firmware/ZigBee%20Module/V2_tube_zb_gw_cc2752p2/ESPHome/tube_zb_gw_cc2652p2v2.yml

